### PR TITLE
Fix typo: SecureBinary -> SecretBinary

### DIFF
--- a/doc_source/intro.md
+++ b/doc_source/intro.md
@@ -100,7 +100,7 @@ You can work with Secrets Manager in any of the following ways:
 **AWS Management Console**  
 [The Secrets Manager console](https://console.aws.amazon.com/secretsmanager/) is a browser\-based interface that you can use to manage your secrets\. You can perform almost any task that's related to your secrets by using the console\.  
 Currently, you can't do the following in the console:  
-+ *Store binary data in a secret\.* The console currently stores data only in the `SecretString` field of the secret, and doesn't use the `SecureBinary` field\. To store binary data, you must currently use the AWS CLI or one of the AWS SDKs\. 
++ *Store binary data in a secret\.* The console currently stores data only in the `SecretString` field of the secret, and doesn't use the `SecretBinary` field\. To store binary data, you must currently use the AWS CLI or one of the AWS SDKs\. 
 
 **AWS Command Line Tools**  
 The AWS command line tools let you issue commands at your system's command line to perform Secrets Manager and other AWS tasks\. This can be faster and more convenient than using the console\. The command line tools also are useful if you want to build scripts that perform AWS tasks\.  


### PR DESCRIPTION
I saw `SecureBinary` referenced here and nowhere else; I figure it's a typo?