### PR TITLE
Update integrating_csi_driver.md

### DIFF
--- a/doc_source/integrating_csi_driver.md
+++ b/doc_source/integrating_csi_driver.md
@@ -12,6 +12,9 @@ With ASCP, you can securely store and manage your secrets in Secrets Manager, as
 
 ## Prerequisites<a name="csi_prerequisites"></a>
 
+**Note**
+This CSI driver is not suitable for EKS Fargate.
+
 Before you can configure ASCP and Kubernetes, you must have the following items:
 + An AWS account
 + An AWS Identity and Access Management account with permissions to modify an Secrets Manager\.


### PR DESCRIPTION
This driver is not suitable for EKS Fargate

*Issue #, if available:*

This Kubernetes operator does not work on EKS Fargate as it need daemon set as base which not support by fargate

*Description of changes:*
Added a note that driver is not suitable for application running on fargate.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
