### PR TITLE
UserId in arn as variable

### DIFF
--- a/doc_source/tutorials_basic.md
+++ b/doc_source/tutorials_basic.md
@@ -114,7 +114,7 @@ In this step, you retrieve the secret by using the Secrets Manager console and t
    ```
    $ aws secretsmanager describe-secret --secret-id tutorials/MyFirstSecret
    {
-       "ARN": "arn:aws::secretsmanager:region:123456789012:secret:tutorials/MyFirstSecret-jiObOV",
+       "ARN": "arn:aws::secretsmanager:region:account-id:secret:tutorials/MyFirstSecret-jiObOV",
        "Name": "tutorials/MyFirstSecret",
        "Description": "Basic Create Secret",
        "LastChangedDate": 1522680794.8,
@@ -134,7 +134,7 @@ In this step, you retrieve the secret by using the Secrets Manager console and t
    ```
    $ aws secretsmanager get-secret-value --secret-id tutorials/MyFirstSecret --version-stage AWSCURRENT
    {
-       "ARN": "arn:secretsmanager:region:123456789012:secret:tutorials/MyFirstSecret-jiObOV",
+       "ARN": "arn:secretsmanager:region:account-id:secret:tutorials/MyFirstSecret-jiObOV",
        "Name": "tutorials/MyFirstSecret",
        "VersionId": "EXAMPLE1-90ab-cdef-fedc-ba987EXAMPLE",
        "SecretString": "S3@ttl3R0cks",


### PR DESCRIPTION
*Description of changes:*
If we're specifying a region in an arn as a variable for unification I propose to change a user-id section of an arn from random numbers to a variable. I think it would be also more understandable for readers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
