### PR TITLE
Update integrating_csi_driver.md

### DIFF
--- a/doc_source/integrating_csi_driver.md
+++ b/doc_source/integrating_csi_driver.md
@@ -21,8 +21,8 @@ The ASCP is available on GitHub in the [secrets\-store\-csi\-provider\-aws](http
 1. To install the Secrets Store CSI Driver, run the following commands\. For full installation instructions, see [Installation](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html) in the Secrets Store CSI Driver Book\.
 
    ```
-   helm repo add secrets-store-csi-driver https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts
-   helm install -n kube-system csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver
+   helm repo add secrets-store-csi-driver https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
+   helm install csi-secrets-store secrets-store-csi-driver/secrets-store-csi-driver --namespace kube-system
    ```
 
 1. To install the ASCP, use the YAML file in the GitHub repo deployment directory\.


### PR DESCRIPTION
*Issue #, if available:*

Current instructions fail

```
helm repo add secrets-store-csi-driver https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts
Error: looks like "https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts" is not a valid chart repository or cannot be reached: failed to fetch https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts/index.yaml : 404 Not Found
```


*Description of changes:*

Corrected the URL per instructions at  https://secrets-store-csi-driver.sigs.k8s.io/getting-started/installation.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
