### PR TITLE
Fix broken using statement & bring .NET Secrets Manager cache example inline with official naming conventions

### DIFF
--- a/doc_source/retrieving-secrets_cache-net.md
+++ b/doc_source/retrieving-secrets_cache-net.md
@@ -29,21 +29,22 @@ To get the package from `Nuget`:
 The following code example shows a method that retrieves a secret named *MySecret*\.  
 
 ```
-using System;
-using Amazon.SecretsManager.Extensions.Caching.SecretsManagerCache;
+using Amazon.SecretsManager.Extensions.Caching;
 
-namespace LambdaExample {
-    public class CachingExample 
+namespace LambdaExample
+{
+    public class CachingExample
     {
-        private SecretsManagerCache cache = new SecretsManagerCache();
-        private const String MySecretName ="MySecret";
+        private const string MySecretName = "MySecret";
 
-        public async Task<Response>  FunctionHandlerAsync(String input, ILambdaContext context)
+        private SecretsManagerCache cache = new SecretsManagerCache();
+
+        public async Task<Response> FunctionHandlerAsync(string input, ILambdaContext context)
         {
-            String MySecret = await cache.GetSecretString(MySecretName);
-            
+            string mySecret = await cache.GetSecretString(MySecretName);
+
             // Use the secret, return success
-            
+
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

1. The current using statement in the code example is incorrect and will yield a compilation error, as `Amazon.SecretsManager.Extensions.Caching.SecretsManagerCache` is a type and not a namespace. The correct namespace is `Amazon.SecretsManager.Extensions.Caching;`.

2. According to general naming conventions in open-source .NET code and stylings suggested by Visual Studio, `string` is preferred over `String`, local variables should be camelCase and not PascalCase and constants should be 1st in terms of ordering. Using `string` also means we can remove the `using System;` :)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
