### PR TITLE
Add a .NET example showing how to configure the cache item TTL for the Secrets Manager cache

### DIFF
--- a/doc_source/retrieving-secrets_cache-net.md
+++ b/doc_source/retrieving-secrets_cache-net.md
@@ -48,3 +48,35 @@ namespace LambdaExample {
     }
 }
 ```
+
+**Example: Configuring the cache refresh duration / time to live (TTL)**  
+The following code example shows a method that retrieve a secret named *MySecret*, with a configured cache refresh duration of 24 hours after which the secret is refreshed.
+
+This is done by instantiating the `SecretCacheConfiguration` class with the `CacheItemTTL` property set to `86400000` ms (24 hours) and then passing the object into the constructor of the `SecretsManagerCache` class.
+
+```
+using Amazon.SecretsManager.Extensions.Caching;
+
+namespace LambdaExample
+{
+    public class CachingExample
+    {
+        private const string MySecretName = "MySecret";
+        
+        private static SecretCacheConfiguration cacheConfiguration = new SecretCacheConfiguration
+        {
+            CacheItemTTL = 86400000
+        };
+
+        private SecretsManagerCache cache = new SecretsManagerCache(cacheConfiguration);
+
+        public async Task<Response> FunctionHandlerAsync(string input, ILambdaContext context)
+        {
+            string mySecret = await cache.GetSecretString(MySecretName);
+
+            // Use the secret, return success
+
+        }
+    }
+}
+```


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
I recently answered an [SO question](https://stackoverflow.com/questions/73517239/what-is-the-azure-key-vault-reference-equivalent-in-aws-secrets-manager), in which I referenced the _Retrieve AWS Secrets Manager secrets in .NET applications_ page. I needed an example showing how to configure the cache item refresh TTL and was surprised that this example didn't exist.

I thought this PR - adding such an example - would be great to solidify the examples on the aforementioned page, so they can be pointed to more often as a useful reference. Configuring the cache TTL is a very common question in my experience. While the ability to change the 1-hour default TTL is mentioned - the _what_ - there is no concrete example for the _how_.

Feel free to change wording etc.

I look forward to hearing your thoughts :)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
