### PR TITLE
Clarify .NET's maximum cache item TTL & cache size

### DIFF
--- a/doc_source/retrieving-secrets_cache-net-SecretCacheConfiguration.md
+++ b/doc_source/retrieving-secrets_cache-net-SecretCacheConfiguration.md
@@ -8,13 +8,13 @@ Cache configuration options for a [SecretsManagerCache](retrieving-secrets_cache
 
 `public uint CacheItemTTL { get; set; }`
 
-The TTL of a cache item in milliseconds\. The default is `3600000` ms or 1 hour\. 
+The TTL of a cache item in milliseconds\. The default is `3600000` ms or 1 hour\. The maximum is `4294967295` ms or approximately 49.7 days\.
 
 ### MaxCacheSize<a name="retrieving-secrets_cache-net-SecretCacheConfiguration-properties_MaxCacheSize"></a>
 
 `public ushort MaxCacheSize { get; set; }`
 
-The maximum cache size\. The default is 1024 secrets\.
+The maximum cache size\. The default is 1024 secrets\. The maximum is 65,535.
 
 ### VersionStage<a name="retrieving-secrets_cache-net-SecretCacheConfiguration-properties_VersionStage"></a>
 


### PR DESCRIPTION
*Issue #, if available:*
N/A 

*Description of changes:*
This aims to clarify the maximum theoretical limits for `CacheItemTTL` and `MaxCacheSize`, based on officially documented [C# data type limits](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types).

It saves time on searching the limits and creates more detailed documentation considering that there are no API docs (since the caching component is a Nuget package).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
