### PR TITLE
update the example apiVersion to `v1`

### DIFF
--- a/doc_source/integrating_csi_driver.md
+++ b/doc_source/integrating_csi_driver.md
@@ -110,7 +110,7 @@ The following example shows a `SecretProviderClass` that mounts six files in Ama
 1. A specific version of a secret\.
 
 ```
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: aws-secrets


### PR DESCRIPTION

*Issue #, if available:*

Applying the SecretProviderClass is throwing a warning:
```
Warning: secrets-store.csi.x-k8s.io/v1alpha1 is deprecated. Use secrets-store.csi.x-k8s.io/v1 instead.
```

*Description of changes:*

The proposition is to update the apiVersion to `v1`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
