### PR TITLE
Fix minor spelling mistakes for monitoring-cloudwatch.md

### DIFF
--- a/doc_source/monitoring-cloudwatch.md
+++ b/doc_source/monitoring-cloudwatch.md
@@ -25,9 +25,9 @@ Dimensions for the Secrets Manager metrics\.
 
 |  Dimension  |  Description  | 
 | --- | --- | 
-|  Service  | The name of the AWS service containing the resource\. For Secrets Manager, the value for this dimention is Secrets Manager\. | 
-|  Type  | The type of entity that is being reported\. For Secrets Manager, the value for this dimention is Resource\. | 
-|  Resource  | The type of resource that is running\. For Secrets Manager, the value for this dimention is SecretCount\. | 
+|  Service  | The name of the AWS service containing the resource\. For Secrets Manager, the value for this dimension is Secrets Manager\. | 
+|  Type  | The type of entity that is being reported\. For Secrets Manager, the value for this dimension is Resource\. | 
+|  Resource  | The type of resource that is running\. For Secrets Manager, the value for this dimension is SecretCount\. | 
 |  Class  | None\. | 
 
 Secrets Manager API requests that you can monitor using CloudWatch metrics include `GetSecretValue`, `DescribeSecret`, `ListSecrets`, and others\. To find metrics, in the CloudWatch console, choose **All metrics**, and then in the search box, enter your search term, for example **secrets**\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix minor spelling mistake of 'dimention'. Not sure what the L51 change is, perhaps hidden characters / newline variations?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
